### PR TITLE
guard against secret tooltips

### DIFF
--- a/handlers/Tooltip.lua
+++ b/handlers/Tooltip.lua
@@ -5,7 +5,7 @@ local function AddTextToTooltip(tooltip, source, map, lootDate, itemCount)
 	for i = 1, 30 do
 		frame = _G[tooltip:GetName() .. "TextLeft" .. i]
 		if frame then text = frame:GetText() end
-		if text and string.find(text, addonName) then return end
+		if text and (issecretvalue(text) or string.find(text, addonName)) then return end
 	end
 
 	tooltip:AddLine("\n")


### PR DESCRIPTION
sometimes, a tooltip can gain the text secret aspect, at which point it's impossible to actually scan its text contents. i think this is related to looting while in combat? perhaps there's more that "should" be done to fix the problem but at the very least, LastSeen should abort if it discovers that blizzard doesn't want it to look at the tooltip of an item, instead of spamming errors every time you mouse over items in your bag.